### PR TITLE
Add highliting for inline font specifiers

### DIFF
--- a/syntaxes/troff.tmLanguage
+++ b/syntaxes/troff.tmLanguage
@@ -103,6 +103,34 @@
 				<key>name</key>
 				<string>operand.troff</string>
 			</dict>
+			<dict>
+				<key>captures</key>
+				<dict>
+					<key>1</key>
+					<dict>
+						<key>name</key>
+						<string>keyword.other.troff</string>
+					</dict>
+				</dict>
+				<key>match</key>
+				<string>(\\f\w)</string>
+				<key>name</key>
+				<string>operand.troff</string>
+			</dict>
+			<dict>
+				<key>captures</key>
+				<dict>
+					<key>1</key>
+					<dict>
+						<key>name</key>
+						<string>keyword.other.troff</string>
+					</dict>
+				</dict>
+				<key>match</key>
+				<string>(\\f\(\w\w)</string>
+				<key>name</key>
+				<string>operand.troff</string>
+			</dict>
 		</array>
 		<key>scopeName</key>
 		<string>text.troff</string>


### PR DESCRIPTION
Hello. I like your extension and I miss inline escapes highlighting in it. In particular, I want it for inline font changing.

In this pr I have added highlighting for some of escapes, which are used most frequently in my opinion: `\fX` and `\f(XX` (first one is also used on the screenshot from README). These escapes are described in the section 5.17.1 of the [groff documentation][1].

[1]: https://www.gnu.org/software/groff/manual/groff.html#Changing-Fonts

It is my first work with VS code extensions, so I just made it by your example.

There is example of the updated highlighting below. I had considering another color for it, but I couldn't find enough information. Anyway, I think that text becomes more readable even with this color.

![before2](https://user-images.githubusercontent.com/35898947/179839086-8eeaced9-57ed-4009-90a9-9b7519bc6290.png)
![after2](https://user-images.githubusercontent.com/35898947/179839082-26b6ea15-d238-4a01-9b92-78fc8fa60ef8.png)